### PR TITLE
Dynamically changing the component did not reflect changes

### DIFF
--- a/src/ReactAnimatedWeather.js
+++ b/src/ReactAnimatedWeather.js
@@ -3,26 +3,34 @@ import PropTypes from 'prop-types';
 import skycons from './skycons';
 
 class ReactAnimatedWeather extends React.Component {
-  componentDidMount() {
-    let skyconIcon = new skycons({
-      color: this.props.color
-    });
 
-    skyconIcon.add(this.skycon, skycons[this.props.icon]);
-    if (this.props.animate) {
-      skyconIcon.play();
-    }
-    // skyconIcon.set(this.skycon, skycons.PARTLY_CLOUDY_NIGHT);
-    // skyconIcon.pause();
+  constructor(props) {
+    super(props);
+
+    this.skyconIcon = new skycons({
+      color: props.color
+    });
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    if (prevProps.icon !== this.props.icon) {
-      let skyconIcon = new skycons({
-        color: this.props.color
-      });
-      skyconIcon.add(this.skycon, skycons[this.props.icon]);
+  setIcon(icon, animate) {
+    this.skyconIcon.add(this.skycon, skycons[icon]);
+
+    if (animate) {
+      this.skyconIcon.play();
     }
+  }
+
+  componentDidMount() {
+    this.setIcon(this.props.icon, this.props.animate);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.skyconIcon = new skycons({
+      color: nextProps.color
+    });
+
+    this.setIcon(nextProps.icon, nextProps.animate);
+    this.forceUpdate()
   }
 
   render() {

--- a/src/ReactAnimatedWeather.js
+++ b/src/ReactAnimatedWeather.js
@@ -4,7 +4,7 @@ import skycons from './skycons';
 
 class ReactAnimatedWeather extends React.Component {
   componentDidMount() {
-    const skyconIcon = new skycons({
+    let skyconIcon = new skycons({
       color: this.props.color
     });
 
@@ -14,6 +14,15 @@ class ReactAnimatedWeather extends React.Component {
     }
     // skyconIcon.set(this.skycon, skycons.PARTLY_CLOUDY_NIGHT);
     // skyconIcon.pause();
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (prevProps.icon !== this.props.icon) {
+      let skyconIcon = new skycons({
+        color: this.props.color
+      });
+      skyconIcon.add(this.skycon, skycons[this.props.icon]);
+    }
   }
 
   render() {


### PR DESCRIPTION
If you ran the component in a "live" environment. Meaning you want to change the component props and have the canvas refresh based on some data (hot - yellow, cold - white, different icon), the component would not change even though the react component did get re-rendered due to new props.

The solution was to actually wait for the props and force the update with a new instance of skyconIcon.