### PR TITLE
Fix significant memory leak

### DIFF
--- a/src/ReactAnimatedWeather.js
+++ b/src/ReactAnimatedWeather.js
@@ -17,6 +17,14 @@ class ReactAnimatedWeather extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    // If color props match, don't reinitialize the icon
+    if (this.skyconIcon.color === nextProps.color) {
+      return;
+    }
+
+    // Remove the old icon
+    this.skyconIcon.remove(this.skycon);
+
     this.skyconIcon = new Skycons({
       color: nextProps.color
     });
@@ -37,7 +45,9 @@ class ReactAnimatedWeather extends React.Component {
     const { size } = this.props;
     return (
       <canvas
-        ref={(canvas) => { this.skycon = canvas; }}
+        ref={canvas => {
+          this.skycon = canvas;
+        }}
         width={size}
         height={size}
       />


### PR DESCRIPTION
There is a significant memory leak that will cause 100% cpu usage that will result in the browser crashing

This is because on props change (whether the props actually did change or not), the icon will be reinitialized and played immediately. The old icon is not destroyed either so it creates a new copy on each rerender

This checks to make sure the props do actually change and removes the old icon if we do reinitialize the icon

**Edit**

Fixes #3 