### PR TITLE
Fix: icon resize with animate false

### DIFF
--- a/src/ReactAnimatedWeather.js
+++ b/src/ReactAnimatedWeather.js
@@ -15,14 +15,14 @@ const ReactAnimatedWeather = ({
   const skyconCanvas = useRef(null);
 
   useEffect(() => {
-    const skyconIcon = new Skycons({ color });
+    const skyconIcon = new Skycons({ color, resizeClear: true });
     const canvas = skyconCanvas.current;
     setIcon(icon, animate, skyconIcon, canvas);
 
     return () => {
       skyconIcon.remove(canvas);
     };
-  }, [icon, color, animate]);
+  }, [icon, color, animate, size]);
 
   return <canvas ref={skyconCanvas} width={size} height={size} />;
 };


### PR DESCRIPTION
Fixing #16
- Added `size` to the dependencies
- Instantiating the class with `resizeClear: true`