### PR TITLE
Use javascript default value assignment for props.

### DIFF
--- a/src/ReactAnimatedWeather.js
+++ b/src/ReactAnimatedWeather.js
@@ -10,7 +10,10 @@ function setIcon(icon, animate, skyconIcon, canvas) {
 }
 
 const ReactAnimatedWeather = ({
-  icon, color, size, animate
+  icon,
+  color = 'black',
+  size = 64,
+  animate = true
 }) => {
   const skyconCanvas = useRef(null);
 
@@ -25,12 +28,6 @@ const ReactAnimatedWeather = ({
   }, [icon, color, animate, size]);
 
   return <canvas ref={skyconCanvas} width={size} height={size} />;
-};
-
-ReactAnimatedWeather.defaultProps = {
-  animate: true,
-  size: 64,
-  color: 'black'
 };
 
 ReactAnimatedWeather.propTypes = {


### PR DESCRIPTION
I came across this warning as an error message in console:
<img width="1080" alt="image" src="https://github.com/user-attachments/assets/ab85868a-5e6d-4605-8feb-1f8308cf332d">

Some looking around lead to this thread:
https://github.com/facebook/react/issues/29233

Does this fix the warning?